### PR TITLE
Fixed-Sticky-Navbar

### DIFF
--- a/02.lovely-movies/scripts/index.js
+++ b/02.lovely-movies/scripts/index.js
@@ -6,6 +6,8 @@ const searchInput = document.getElementById("search");
 const searchTrendSpan = document.getElementById("search-trend");
 const pageNumberSpan = document.getElementById("page-number");
 const nextBtn = document.getElementById("next-btn");
+const nav=document.querySelector(".main-header")
+
 
 let SEARCH_DEBOUNCE_FLAG = null;
 let CURRENT_PAGE = 1;
@@ -234,3 +236,20 @@ function showMovieInDetails(movieObj, targetItem) {
 
     detailsWrapper.append(detailsElm);
 }
+
+
+
+
+//Fixed Navigation
+
+const coords=nav.getBoundingClientRect()
+window.addEventListener("scroll",function(){
+
+if(window.scrollY>coords.top){
+    nav.classList.add("sticky");
+    
+}else{
+    nav.classList.remove("sticky")
+}
+})
+

--- a/02.lovely-movies/styles/styles.css
+++ b/02.lovely-movies/styles/styles.css
@@ -75,6 +75,11 @@ body.loading .loader {
     box-shadow: 0 1px 10px 2px rgba(0, 0, 0, 0.3);
     height: 70px;
 }
+.sticky{
+    position: fixed;
+    z-index: 10;
+    width: 100%;
+}
 
 .main-header__branding {
     flex: 0 0 160px;


### PR DESCRIPTION

An issue was raised to make the Navbar on the Lovely website fixed during scrolling.



### Expected Behavior

When the user scrolls up the page the navbar sticks and the top and can always be seen by the user. 



### Screenshots
<img width="631" alt="Screen Shot 2023-01-08 at 12 31 40 PM" src="https://user-images.githubusercontent.com/95531716/211210295-99473c4d-3029-442c-a345-1b593b961e5f.png">

